### PR TITLE
Disable auto-update if the AUR is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,24 @@ the future, see the [corresponding issue](https://github.com/marvk/vatprism/issu
 
 #### Linux
 
-Currently, there is no support for native linux binaries. It is still possible to run VATprism, though you are going to
+If you are using Arch Linux or any derivatives, you can use the third-party [vatprism](https://aur.archlinux.org/packages/vatprism)
+package on the AUR.   
+
+Using `yay` as your AUR helper...   
+```
+yay -Sy vatprism
+``` 
+
+Using no AUR helper...   
+```
+git clone https://aur.archlinux.org/vatprism.git && cd vatprism
+makepkg -si
+```
+It is still possible to run VATprism on other distros, though you are going to
 have to compile it yourself. For this, please refer to the [Build](#build) section of this readme.
 
-If there is demand for Linux native binaries in the future, I will think about adding support. Feel free to
-request [Linux](https://github.com/marvk/vatprism/issues/31) builds via the linked issue.
+If there is demand for more Linux native binaries in the future, I will think about adding support. Feel free to
+request different [Linux](https://github.com/marvk/vatprism/issues/31) builds via the linked issue.
 
 ## Build
 

--- a/src/main/java/net/marvk/fs/vatsim/map/data/ConfigFilePreferences.java
+++ b/src/main/java/net/marvk/fs/vatsim/map/data/ConfigFilePreferences.java
@@ -63,6 +63,7 @@ public class ConfigFilePreferences implements Preferences, Writable {
         booleanProperty("general.prereleases", false);
         booleanProperty("general.delete_old_logs", true);
         stringProperty("meta.version", "0.0.0");
+        stringProperty("meta.install_method", "default");
 
         booleanProperty("ui.auto_color", true);
         booleanProperty("ui.auto_shade", true);

--- a/src/main/java/net/marvk/fs/vatsim/map/view/preloader/PreloaderView.java
+++ b/src/main/java/net/marvk/fs/vatsim/map/view/preloader/PreloaderView.java
@@ -171,6 +171,6 @@ public class PreloaderView implements FxmlView<PreloaderViewModel> {
             method = new File("/etc/vatprism/aur").exists() ? "aur" : "default";
         }
         prefs.stringProperty("meta.install_method").set(method);
-        log.info(method);
+        log.info("Install method - " + method);
     }
 }

--- a/src/main/java/net/marvk/fs/vatsim/map/view/preloader/PreloaderView.java
+++ b/src/main/java/net/marvk/fs/vatsim/map/view/preloader/PreloaderView.java
@@ -2,6 +2,7 @@ package net.marvk.fs.vatsim.map.view.preloader;
 
 import de.saxsys.mvvmfx.FxmlView;
 import de.saxsys.mvvmfx.InjectViewModel;
+import de.saxsys.mvvmfx.internal.viewloader.DependencyInjector;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import javafx.scene.input.MouseButton;
@@ -10,11 +11,14 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Window;
+import lombok.extern.log4j.Log4j2;
 import net.marvk.fs.vatsim.map.api.VersionResponse;
+import net.marvk.fs.vatsim.map.data.Preferences;
 
 import java.time.LocalDate;
 import java.util.Base64;
 
+@Log4j2
 public class PreloaderView implements FxmlView<PreloaderViewModel> {
     @FXML
     private Label header;
@@ -67,7 +71,11 @@ public class PreloaderView implements FxmlView<PreloaderViewModel> {
 
         viewModel.versionResponseProperty().addListener((observable, oldValue, response) -> {
             if (response != null && response.getResult() == VersionResponse.Result.OUTDATED) {
-                showNewVersionDialog(response);
+                final Preferences prefs = DependencyInjector.getInstance().getInstanceOf(Preferences.class);
+                switch (prefs.stringProperty("meta.install_method").get()) {
+                    case "aur" -> showNewVersionDialog(response, "the Arch User Repository");
+                    default -> showNewVersionDialog(response);
+                }
             }
         });
 
@@ -81,7 +89,7 @@ public class PreloaderView implements FxmlView<PreloaderViewModel> {
         final Alert alert = new Alert(Alert.AlertType.INFORMATION);
         alert.initOwner(taskHolder.getScene().getWindow());
         alert.setTitle("New Version Available!");
-        alert.setHeaderText("A new Version of VATprism (%s) is available.".formatted(response.getLatestVersion()));
+        alert.setHeaderText("A new version of VATprism (%s) is available.".formatted(response.getLatestVersion()));
         alert.setContentText("Would you like to download the latest version?");
         alert.getButtonTypes().setAll(download, postpone);
         final TextArea textArea = new TextArea(response.getChangelog());
@@ -102,6 +110,29 @@ public class PreloaderView implements FxmlView<PreloaderViewModel> {
              .filter(e -> e == download)
              .findAny()
              .ifPresent(e -> viewModel.downloadNewVersion());
+    }
+
+    private void showNewVersionDialog(final VersionResponse response, final String alt) {
+        final ButtonType close = new ButtonType("Close");
+
+        final Alert alert = new Alert(Alert.AlertType.INFORMATION);
+        alert.initOwner(taskHolder.getScene().getWindow());
+        alert.setTitle("New Version Available!");
+        alert.setHeaderText("A new version of VATprism (%s) is available.".formatted(response.getLatestVersion()));
+        alert.setContentText("Please update using " + alt + ".");
+        alert.getButtonTypes().setAll(close);
+        final TextArea textArea = new TextArea(response.getChangelog());
+        textArea.setEditable(false);
+        textArea.setWrapText(true);
+        textArea.setPrefHeight(100);
+        final VBox changelogBox = new VBox(new Label("Changelog:"), textArea);
+        alert.getDialogPane().setExpandableContent(changelogBox);
+        alert.getDialogPane().setExpanded(true);
+        final Window window = alert.getDialogPane().getScene().getWindow();
+        window.setOnCloseRequest(e -> window.hide());
+
+        ((Button) alert.getDialogPane().lookupButton(close)).setDefaultButton(true);
+        alert.showAndWait();
     }
 
     @FXML


### PR DESCRIPTION
I realised that with the built in auto-update system sort of clashes with the AUR package. I created a simple way to detect if the program was installed through the AUR (check if a file created by the AUR package exists), then enable or disable the auto-update system accordingly. It displays an alternate message telling the user to update through the AUR. I also updated the `README.md` with the AUR installation instructions. If you accept this PR, I'll get on implementing the functionality into the AUR package ASAP.

I wasn't sure what branch to submit this to, so I just did `master`. If you'd like me to resubmit this to `features/0.3.5` or something else, go ahead and tell me.