### PR TITLE
Fix build on JDK 21+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <java.version>15</java.version>
-        <lombok.version>1.18.22</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         <javafx.version>17.0.1</javafx.version>
         <slf4j.version>1.7.32</slf4j.version>
         <mvvmfx.version>1.9.0-SNAPSHOT</mvvmfx.version>


### PR DESCRIPTION
Lombok 1.18.22 doesn't work on JDK 21+. The earliest version with support is 1.18.30.